### PR TITLE
Add deterministic comps calculator

### DIFF
--- a/comps-service/comps_service/calculator.py
+++ b/comps-service/comps_service/calculator.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from statistics import median
+from uuid import UUID
+
+from talk_to_your_stock_shared import (
+    CompsRow,
+    MinMedianMax,
+    RunTableResponse,
+    TraceFormula,
+    TraceInput,
+    TraceOutputField,
+    TraceResponse,
+)
+
+
+class CompsCalculationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class CompanyCompsInput:
+    ticker: str
+    company_name: str | None
+    currency: str
+    share_price: float
+    shares_outstanding: float
+    cash: float
+    total_debt: float
+    revenue_ltm: float
+    ebit_ltm: float
+    ebitda_ltm: float
+    net_income_ltm: float
+    as_of: datetime
+    sources: dict[str, str] = field(default_factory=dict)
+
+
+class CompsCalculator:
+    def generate(
+        self,
+        *,
+        run_id: UUID,
+        target_ticker: str,
+        companies: list[CompanyCompsInput],
+        currency: str,
+    ) -> tuple[RunTableResponse, TraceResponse]:
+        self._validate_inputs(target_ticker=target_ticker, companies=companies)
+
+        target = target_ticker.upper()
+        rows: list[CompsRow] = []
+        formulas: list[TraceFormula] = []
+
+        for company in companies:
+            market_cap = self._round(company.share_price * company.shares_outstanding)
+            net_debt = self._round(company.total_debt - company.cash)
+            enterprise_value = self._round(market_cap + net_debt)
+            ev_to_revenue = self._safe_ratio(enterprise_value, company.revenue_ltm)
+            ev_to_ebit = self._safe_ratio(enterprise_value, company.ebit_ltm)
+            ev_to_ebitda = self._safe_ratio(enterprise_value, company.ebitda_ltm)
+            pe = self._safe_ratio(market_cap, company.net_income_ltm)
+
+            rows.append(
+                CompsRow(
+                    ticker=company.ticker.upper(),
+                    company_name=company.company_name,
+                    is_target=company.ticker.upper() == target,
+                    currency=currency or company.currency,
+                    share_price=company.share_price,
+                    shares_outstanding=company.shares_outstanding,
+                    market_cap=market_cap,
+                    cash=company.cash,
+                    total_debt=company.total_debt,
+                    net_debt=net_debt,
+                    enterprise_value=enterprise_value,
+                    revenue_ltm=company.revenue_ltm,
+                    ebit_ltm=company.ebit_ltm,
+                    ebitda_ltm=company.ebitda_ltm,
+                    net_income_ltm=company.net_income_ltm,
+                    ev_to_revenue=ev_to_revenue,
+                    ev_to_ebit=ev_to_ebit,
+                    ev_to_ebitda=ev_to_ebitda,
+                    pe=pe,
+                    as_of=company.as_of,
+                )
+            )
+            formulas.extend(
+                self._trace_formulas(
+                    company=company,
+                    market_cap=market_cap,
+                    net_debt=net_debt,
+                    enterprise_value=enterprise_value,
+                    ev_to_revenue=ev_to_revenue,
+                    ev_to_ebit=ev_to_ebit,
+                    ev_to_ebitda=ev_to_ebitda,
+                    pe=pe,
+                )
+            )
+
+        table = RunTableResponse(
+            run_id=run_id,
+            target_ticker=target,
+            currency=currency,
+            as_of=max(company.as_of for company in companies),
+            rows=rows,
+            summary={
+                "stats": {
+                    "ev_to_revenue": self._stats([row.ev_to_revenue for row in rows]),
+                    "ev_to_ebit": self._stats([row.ev_to_ebit for row in rows]),
+                    "ev_to_ebitda": self._stats([row.ev_to_ebitda for row in rows]),
+                    "pe": self._stats([row.pe for row in rows]),
+                }
+            },
+        )
+        return table, TraceResponse(run_id=run_id, formulas=formulas)
+
+    def _validate_inputs(
+        self,
+        *,
+        target_ticker: str,
+        companies: list[CompanyCompsInput],
+    ) -> None:
+        if not companies:
+            raise CompsCalculationError("At least one company is required.")
+
+        seen: set[str] = set()
+        for company in companies:
+            ticker = company.ticker.upper()
+            if ticker in seen:
+                raise CompsCalculationError(f"Duplicate ticker input: {ticker}.")
+            seen.add(ticker)
+
+        if target_ticker.upper() not in seen:
+            raise CompsCalculationError(
+                f"Target ticker {target_ticker.upper()} is missing from company inputs."
+            )
+
+    def _trace_formulas(
+        self,
+        *,
+        company: CompanyCompsInput,
+        market_cap: float,
+        net_debt: float,
+        enterprise_value: float,
+        ev_to_revenue: float | None,
+        ev_to_ebit: float | None,
+        ev_to_ebitda: float | None,
+        pe: float | None,
+    ) -> list[TraceFormula]:
+        return [
+            TraceFormula(
+                ticker=company.ticker.upper(),
+                output_field=TraceOutputField.EQUITY_VALUE,
+                expression="share_price * shares_outstanding",
+                output_value=market_cap,
+                inputs=[
+                    self._trace_input(company, "share_price"),
+                    self._trace_input(company, "shares_outstanding"),
+                ],
+            ),
+            TraceFormula(
+                ticker=company.ticker.upper(),
+                output_field=TraceOutputField.NET_DEBT,
+                expression="total_debt - cash",
+                output_value=net_debt,
+                inputs=[
+                    self._trace_input(company, "total_debt"),
+                    self._trace_input(company, "cash"),
+                ],
+            ),
+            TraceFormula(
+                ticker=company.ticker.upper(),
+                output_field=TraceOutputField.ENTERPRISE_VALUE,
+                expression="equity_value + net_debt",
+                output_value=enterprise_value,
+                inputs=[
+                    TraceInput(
+                        field="equity_value",
+                        value=market_cap,
+                        source="calculated.equity_value",
+                        as_of=company.as_of,
+                    ),
+                    TraceInput(
+                        field="net_debt",
+                        value=net_debt,
+                        source="calculated.net_debt",
+                        as_of=company.as_of,
+                    ),
+                ],
+            ),
+            self._multiple_trace(
+                company=company,
+                field=TraceOutputField.EV_TO_REVENUE,
+                denominator_field="revenue_ltm",
+                output_value=ev_to_revenue,
+                enterprise_value=enterprise_value,
+            ),
+            self._multiple_trace(
+                company=company,
+                field=TraceOutputField.EV_TO_EBIT,
+                denominator_field="ebit_ltm",
+                output_value=ev_to_ebit,
+                enterprise_value=enterprise_value,
+            ),
+            self._multiple_trace(
+                company=company,
+                field=TraceOutputField.EV_TO_EBITDA,
+                denominator_field="ebitda_ltm",
+                output_value=ev_to_ebitda,
+                enterprise_value=enterprise_value,
+            ),
+            TraceFormula(
+                ticker=company.ticker.upper(),
+                output_field=TraceOutputField.PE,
+                expression="equity_value / net_income_ltm",
+                output_value=pe,
+                inputs=[
+                    TraceInput(
+                        field="equity_value",
+                        value=market_cap,
+                        source="calculated.equity_value",
+                        as_of=company.as_of,
+                    ),
+                    self._trace_input(company, "net_income_ltm"),
+                ],
+            ),
+        ]
+
+    def _multiple_trace(
+        self,
+        *,
+        company: CompanyCompsInput,
+        field: TraceOutputField,
+        denominator_field: str,
+        output_value: float | None,
+        enterprise_value: float,
+    ) -> TraceFormula:
+        return TraceFormula(
+            ticker=company.ticker.upper(),
+            output_field=field,
+            expression=f"enterprise_value / {denominator_field}",
+            output_value=output_value,
+            inputs=[
+                TraceInput(
+                    field="enterprise_value",
+                    value=enterprise_value,
+                    source="calculated.enterprise_value",
+                    as_of=company.as_of,
+                ),
+                self._trace_input(company, denominator_field),
+            ],
+        )
+
+    def _trace_input(self, company: CompanyCompsInput, field_name: str) -> TraceInput:
+        return TraceInput(
+            field=field_name,
+            value=getattr(company, field_name),
+            source=company.sources.get(field_name, f"input.{field_name}"),
+            as_of=company.as_of,
+        )
+
+    def _safe_ratio(self, numerator: float | None, denominator: float | None) -> float | None:
+        if numerator is None or denominator in (None, 0):
+            return None
+        return self._round(numerator / denominator)
+
+    def _stats(self, values: list[float | None]) -> MinMedianMax:
+        present = sorted(value for value in values if value is not None)
+        if not present:
+            return MinMedianMax(min=None, median=None, max=None)
+        return MinMedianMax(
+            min=present[0],
+            median=self._round(float(median(present))),
+            max=present[-1],
+        )
+
+    def _round(self, value: float) -> float:
+        return round(value, 2)

--- a/comps-service/tests/test_calculator.py
+++ b/comps-service/tests/test_calculator.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import unittest
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from comps_service.calculator import (
+    CompanyCompsInput,
+    CompsCalculationError,
+    CompsCalculator,
+)
+from talk_to_your_stock_shared import TraceOutputField
+
+
+class CompsCalculatorTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.calculator = CompsCalculator()
+        self.as_of = datetime(2026, 6, 26, tzinfo=UTC)
+
+    def test_generate_calculates_expected_comps_table(self) -> None:
+        table, trace = self.calculator.generate(
+            run_id=uuid4(),
+            target_ticker="AAPL",
+            companies=[self._company("AAPL")],
+            currency="USD",
+        )
+
+        row = table.rows[0]
+        self.assertTrue(row.is_target)
+        self.assertEqual(row.market_cap, 1000)
+        self.assertEqual(row.net_debt, 300)
+        self.assertEqual(row.enterprise_value, 1300)
+        self.assertEqual(row.ev_to_revenue, 5.2)
+        self.assertEqual(row.ev_to_ebit, 13.0)
+        self.assertEqual(row.ev_to_ebitda, 10.4)
+        self.assertEqual(row.pe, 20.0)
+
+        self.assertEqual(table.summary.stats.ev_to_revenue.min, 5.2)
+        self.assertEqual(table.summary.stats.ev_to_revenue.median, 5.2)
+        self.assertEqual(table.summary.stats.ev_to_revenue.max, 5.2)
+        self.assertEqual(table.summary.stats.ev_to_ebit.min, 13.0)
+        self.assertEqual(table.summary.stats.ev_to_ebitda.min, 10.4)
+        self.assertEqual(table.summary.stats.pe.min, 20.0)
+
+        self.assertEqual(trace.run_id, table.run_id)
+        self.assertEqual(
+            {formula.output_field for formula in trace.formulas},
+            {
+                TraceOutputField.EQUITY_VALUE,
+                TraceOutputField.NET_DEBT,
+                TraceOutputField.ENTERPRISE_VALUE,
+                TraceOutputField.EV_TO_REVENUE,
+                TraceOutputField.EV_TO_EBIT,
+                TraceOutputField.EV_TO_EBITDA,
+                TraceOutputField.PE,
+            },
+        )
+
+    def test_zero_denominators_return_none_and_stats_ignore_none(self) -> None:
+        table, _trace = self.calculator.generate(
+            run_id=uuid4(),
+            target_ticker="AAPL",
+            companies=[
+                self._company(
+                    "AAPL",
+                    revenue_ltm=0,
+                    ebit_ltm=0,
+                    ebitda_ltm=0,
+                    net_income_ltm=0,
+                ),
+                self._company("MSFT"),
+            ],
+            currency="USD",
+        )
+
+        target_row = table.rows[0]
+        peer_row = table.rows[1]
+        self.assertIsNone(target_row.ev_to_revenue)
+        self.assertIsNone(target_row.ev_to_ebit)
+        self.assertIsNone(target_row.ev_to_ebitda)
+        self.assertIsNone(target_row.pe)
+
+        self.assertEqual(table.summary.stats.ev_to_revenue.min, peer_row.ev_to_revenue)
+        self.assertEqual(table.summary.stats.ev_to_revenue.median, peer_row.ev_to_revenue)
+        self.assertEqual(table.summary.stats.ev_to_revenue.max, peer_row.ev_to_revenue)
+        self.assertEqual(table.summary.stats.pe.min, peer_row.pe)
+
+    def test_missing_target_ticker_raises(self) -> None:
+        with self.assertRaisesRegex(CompsCalculationError, "Target ticker AAPL is missing"):
+            self.calculator.generate(
+                run_id=uuid4(),
+                target_ticker="AAPL",
+                companies=[self._company("MSFT")],
+                currency="USD",
+            )
+
+    def test_duplicate_ticker_raises(self) -> None:
+        with self.assertRaisesRegex(CompsCalculationError, "Duplicate ticker input: AAPL"):
+            self.calculator.generate(
+                run_id=uuid4(),
+                target_ticker="AAPL",
+                companies=[self._company("AAPL"), self._company("aapl")],
+                currency="USD",
+            )
+
+    def test_empty_company_list_raises(self) -> None:
+        with self.assertRaisesRegex(CompsCalculationError, "At least one company"):
+            self.calculator.generate(
+                run_id=uuid4(),
+                target_ticker="AAPL",
+                companies=[],
+                currency="USD",
+            )
+
+    def _company(self, ticker: str, **overrides: float) -> CompanyCompsInput:
+        values = {
+            "share_price": 10.0,
+            "shares_outstanding": 100.0,
+            "cash": 200.0,
+            "total_debt": 500.0,
+            "revenue_ltm": 250.0,
+            "ebit_ltm": 100.0,
+            "ebitda_ltm": 125.0,
+            "net_income_ltm": 50.0,
+        }
+        values.update(overrides)
+        return CompanyCompsInput(
+            ticker=ticker,
+            company_name=f"{ticker.upper()} Inc.",
+            currency="USD",
+            as_of=self.as_of,
+            sources={field: f"fixture.{field}" for field in values},
+            **values,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary of all changes made from the end user perspective

This adds the Phase 2 deterministic comps calculation core for `comps-service`. Given explicit numeric company inputs, the calculator now produces a comps table and formula trace for market cap, net debt, enterprise value, EV/Revenue, EV/EBIT, EV/EBITDA, and P/E.

This PR intentionally does not add provider calls, persistence, cache behavior, API endpoint wiring, export behavior, or local dev setup changes.

Part of #5.

## Explanation of how these changes were made with a mermaid diagram showing the updated flow of things vs the original flow

The calculator is a pure module inside `comps-service`. It accepts already-normalized numeric inputs and returns existing shared response models, so later phases can wire providers, persistence, and APIs around it without mixing those concerns into the math.

```mermaid
flowchart LR
    subgraph Original[Original flow]
        A[No deterministic comps calculator]
        B[Comps math not independently testable]
        A --> B
    end

    subgraph Updated[Updated Phase 2 flow]
        C[CompanyCompsInput list]
        D[CompsCalculator.generate]
        E[RunTableResponse]
        F[TraceResponse]
        C --> D
        D --> E
        D --> F
    end
```

Validation added in the calculator:
- rejects empty input lists
- rejects duplicate tickers
- rejects requests where the target ticker is missing
- returns `None` for multiples with zero denominators
- computes summary stats from non-null multiples only

## Tests ran or added to validate everything

Added `comps-service/tests/test_calculator.py` using Python `unittest`.

Tests cover:
- exact worked formula outputs for market cap, net debt, enterprise value, EV/Revenue, EV/EBIT, EV/EBITDA, and P/E
- zero denominator multiples returning `None`
- summary stats ignoring `None`
- target row marked with `is_target=True`
- missing target ticker raising `CompsCalculationError`
- duplicate ticker inputs raising `CompsCalculationError`
- trace formulas using documented `TraceOutputField` values only

Commands run:

```bash
.venv/bin/python -m compileall shared comps-service
PYTHONPATH=shared:comps-service .venv/bin/python -m unittest discover -s comps-service/tests
```
