### PR TITLE
Add Alpha Vantage provider normalization

### DIFF
--- a/comps-service/comps_service/alpha_vantage.py
+++ b/comps-service/comps_service/alpha_vantage.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable, Mapping
+from json import JSONDecodeError
+from typing import Any
+from urllib.parse import urlencode
+from urllib.error import URLError
+from urllib.request import urlopen
+
+
+class AlphaVantageConfigError(RuntimeError):
+    pass
+
+
+class AlphaVantageProviderError(RuntimeError):
+    pass
+
+
+JsonObject = dict[str, Any]
+RequestJson = Callable[[Mapping[str, str]], JsonObject]
+
+
+class AlphaVantageClient:
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout_seconds: float = 20,
+        request_json: RequestJson | None = None,
+    ) -> None:
+        self.api_key = (api_key if api_key is not None else os.getenv("ALPHA_VANTAGE_API_KEY", "")).strip()
+        self.base_url = base_url or os.getenv("ALPHA_VANTAGE_BASE_URL", "https://www.alphavantage.co/query")
+        self.timeout_seconds = timeout_seconds
+        self._request_json = request_json
+
+    def get_global_quote(self, symbol: str) -> JsonObject:
+        return self._get_json(function="GLOBAL_QUOTE", symbol=symbol)
+
+    def get_overview(self, symbol: str) -> JsonObject:
+        return self._get_json(function="OVERVIEW", symbol=symbol)
+
+    def get_income_statement(self, symbol: str) -> JsonObject:
+        return self._get_json(function="INCOME_STATEMENT", symbol=symbol)
+
+    def get_balance_sheet(self, symbol: str) -> JsonObject:
+        return self._get_json(function="BALANCE_SHEET", symbol=symbol)
+
+    def get_fx_daily(self, from_currency: str, to_currency: str) -> JsonObject:
+        return self._get_json(
+            function="FX_DAILY",
+            from_symbol=from_currency.upper(),
+            to_symbol=to_currency.upper(),
+            outputsize="compact",
+        )
+
+    def _get_json(self, **params: str) -> JsonObject:
+        if not self.api_key:
+            raise AlphaVantageConfigError("ALPHA_VANTAGE_API_KEY is required.")
+
+        request_params = {**params, "apikey": self.api_key}
+        payload = (
+            self._request_json(request_params)
+            if self._request_json is not None
+            else self._urllib_request_json(request_params)
+        )
+        if not isinstance(payload, dict):
+            raise AlphaVantageProviderError("Alpha Vantage returned a non-object JSON payload.")
+        self._raise_for_provider_error(payload)
+        return payload
+
+    def _urllib_request_json(self, params: Mapping[str, str]) -> JsonObject:
+        query = urlencode(params)
+        try:
+            with urlopen(f"{self.base_url}?{query}", timeout=self.timeout_seconds) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except (JSONDecodeError, OSError, URLError) as exc:
+            raise AlphaVantageProviderError("Alpha Vantage request failed.") from exc
+        if not isinstance(payload, dict):
+            raise AlphaVantageProviderError("Alpha Vantage returned a non-object JSON payload.")
+        return payload
+
+    def _raise_for_provider_error(self, payload: JsonObject) -> None:
+        message = (
+            payload.get("Error Message")
+            or payload.get("Information")
+            or payload.get("Note")
+        )
+        if message:
+            raise AlphaVantageProviderError(str(message))

--- a/comps-service/comps_service/provider_normalizer.py
+++ b/comps-service/comps_service/provider_normalizer.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from comps_service.alpha_vantage import AlphaVantageClient
+from comps_service.calculator import CompanyCompsInput
+
+
+class AlphaVantageNormalizationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class FxRate:
+    rate: float
+    date: date
+
+
+class AlphaVantageCompsNormalizer:
+    def __init__(self, client: AlphaVantageClient) -> None:
+        self.client = client
+
+    def normalize_company(self, symbol: str, *, output_currency: str) -> CompanyCompsInput:
+        ticker = symbol.upper()
+        quote = self.client.get_global_quote(ticker)
+        overview = self.client.get_overview(ticker)
+        income_statement = self.client.get_income_statement(ticker)
+        balance_sheet = self.client.get_balance_sheet(ticker)
+
+        quote_payload = self._required_mapping(quote, "Global Quote", "GLOBAL_QUOTE")
+        latest_income_reports = self._required_reports(
+            income_statement,
+            "quarterlyReports",
+            "INCOME_STATEMENT",
+            min_count=4,
+        )[:4]
+        latest_balance = self._required_reports(
+            balance_sheet,
+            "quarterlyReports",
+            "BALANCE_SHEET",
+            min_count=1,
+        )[0]
+
+        source_currency = self._source_currency(overview, latest_income_reports, latest_balance)
+        requested_currency = output_currency.upper()
+        as_of = self._parse_provider_date(
+            self._required_value(quote_payload, "07. latest trading day", "GLOBAL_QUOTE"),
+            "GLOBAL_QUOTE.07. latest trading day",
+        )
+        fx_rate = self._fx_rate(source_currency, requested_currency, as_of.date())
+
+        sources = {
+            "share_price": self._with_fx_source(
+                "alpha_vantage.GLOBAL_QUOTE.05. price",
+                source_currency,
+                requested_currency,
+                fx_rate,
+            ),
+            "shares_outstanding": "alpha_vantage.OVERVIEW.SharesOutstanding",
+            "cash": self._with_fx_source(
+                "alpha_vantage.BALANCE_SHEET.quarterlyReports[0].cashAndCashEquivalentsAtCarryingValue",
+                source_currency,
+                requested_currency,
+                fx_rate,
+            ),
+            "total_debt": self._with_fx_source(
+                "alpha_vantage.BALANCE_SHEET.quarterlyReports[0].shortLongTermDebtTotal",
+                source_currency,
+                requested_currency,
+                fx_rate,
+            ),
+            "revenue_ltm": self._with_fx_source(
+                "alpha_vantage.INCOME_STATEMENT.quarterlyReports[0:4].totalRevenue",
+                source_currency,
+                requested_currency,
+                fx_rate,
+            ),
+            "ebit_ltm": self._with_fx_source(
+                "alpha_vantage.INCOME_STATEMENT.quarterlyReports[0:4].ebit",
+                source_currency,
+                requested_currency,
+                fx_rate,
+            ),
+            "ebitda_ltm": self._with_fx_source(
+                "alpha_vantage.INCOME_STATEMENT.quarterlyReports[0:4].ebitda",
+                source_currency,
+                requested_currency,
+                fx_rate,
+            ),
+            "net_income_ltm": self._with_fx_source(
+                "alpha_vantage.INCOME_STATEMENT.quarterlyReports[0:4].netIncome",
+                source_currency,
+                requested_currency,
+                fx_rate,
+            ),
+        }
+
+        return CompanyCompsInput(
+            ticker=ticker,
+            company_name=self._optional_string(overview.get("Name")),
+            currency=requested_currency,
+            share_price=self._money(quote_payload, "05. price", "GLOBAL_QUOTE") * fx_rate.rate,
+            shares_outstanding=self._number(overview, "SharesOutstanding", "OVERVIEW"),
+            cash=self._money(latest_balance, "cashAndCashEquivalentsAtCarryingValue", "BALANCE_SHEET") * fx_rate.rate,
+            total_debt=self._money(latest_balance, "shortLongTermDebtTotal", "BALANCE_SHEET") * fx_rate.rate,
+            revenue_ltm=self._ltm_money(latest_income_reports, "totalRevenue") * fx_rate.rate,
+            ebit_ltm=self._ltm_money(latest_income_reports, "ebit") * fx_rate.rate,
+            ebitda_ltm=self._ltm_money(latest_income_reports, "ebitda") * fx_rate.rate,
+            net_income_ltm=self._ltm_money(latest_income_reports, "netIncome") * fx_rate.rate,
+            as_of=as_of,
+            sources=sources,
+        )
+
+    def _source_currency(
+        self,
+        overview: dict[str, Any],
+        income_reports: list[dict[str, Any]],
+        balance_report: dict[str, Any],
+    ) -> str:
+        currencies = [
+            self._optional_string(overview.get("Currency")),
+            self._optional_string(income_reports[0].get("reportedCurrency")),
+            self._optional_string(balance_report.get("reportedCurrency")),
+        ]
+        present = {currency.upper() for currency in currencies if currency}
+        if not present:
+            raise AlphaVantageNormalizationError("Alpha Vantage payload is missing currency.")
+        if len(present) > 1:
+            raise AlphaVantageNormalizationError(
+                f"Alpha Vantage payload has inconsistent currencies: {', '.join(sorted(present))}."
+            )
+        return present.pop()
+
+    def _fx_rate(self, source_currency: str, requested_currency: str, as_of: date) -> FxRate:
+        if source_currency == requested_currency:
+            return FxRate(rate=1.0, date=as_of)
+
+        payload = self.client.get_fx_daily(source_currency, requested_currency)
+        series = self._required_mapping(payload, "Time Series FX (Daily)", "FX_DAILY")
+        usable_dates = sorted(
+            (self._parse_date_key(value) for value in series),
+            reverse=True,
+        )
+        fx_date = next((value for value in usable_dates if value <= as_of), None)
+        if fx_date is None:
+            raise AlphaVantageNormalizationError(
+                f"FX rate {source_currency}/{requested_currency} is unavailable for {as_of.isoformat()}."
+            )
+
+        daily_value = series[fx_date.isoformat()]
+        close_value = self._money(daily_value, "4. close", "FX_DAILY")
+        return FxRate(rate=close_value, date=fx_date)
+
+    def _with_fx_source(
+        self,
+        source: str,
+        source_currency: str,
+        requested_currency: str,
+        fx_rate: FxRate,
+    ) -> str:
+        if source_currency == requested_currency:
+            return source
+        return f"{source}; fx={source_currency}/{requested_currency}@{fx_rate.rate} date={fx_rate.date.isoformat()}"
+
+    def _ltm_money(self, reports: list[dict[str, Any]], field_name: str) -> float:
+        return sum(self._money(report, field_name, "INCOME_STATEMENT") for report in reports)
+
+    def _money(self, payload: dict[str, Any], field_name: str, payload_name: str) -> float:
+        return self._number(payload, field_name, payload_name)
+
+    def _number(self, payload: dict[str, Any], field_name: str, payload_name: str) -> float:
+        value = self._required_value(payload, field_name, payload_name)
+        try:
+            return float(Decimal(value.replace(",", "")))
+        except (AttributeError, InvalidOperation, ValueError) as exc:
+            raise AlphaVantageNormalizationError(
+                f"Alpha Vantage {payload_name} field {field_name} is not numeric."
+            ) from exc
+
+    def _required_mapping(self, payload: dict[str, Any], field_name: str, payload_name: str) -> dict[str, Any]:
+        value = payload.get(field_name)
+        if not isinstance(value, dict):
+            raise AlphaVantageNormalizationError(
+                f"Alpha Vantage {payload_name} payload is missing {field_name}."
+            )
+        return value
+
+    def _required_reports(
+        self,
+        payload: dict[str, Any],
+        field_name: str,
+        payload_name: str,
+        *,
+        min_count: int,
+    ) -> list[dict[str, Any]]:
+        value = payload.get(field_name)
+        if not isinstance(value, list) or len(value) < min_count:
+            raise AlphaVantageNormalizationError(
+                f"Alpha Vantage {payload_name} payload needs at least {min_count} {field_name}."
+            )
+        if not all(isinstance(report, dict) for report in value):
+            raise AlphaVantageNormalizationError(
+                f"Alpha Vantage {payload_name} {field_name} must contain object reports."
+            )
+        return value
+
+    def _required_value(self, payload: dict[str, Any], field_name: str, payload_name: str) -> str:
+        value = payload.get(field_name)
+        if value in (None, "", "None", "-"):
+            raise AlphaVantageNormalizationError(
+                f"Alpha Vantage {payload_name} payload is missing {field_name}."
+            )
+        return str(value)
+
+    def _parse_provider_date(self, value: str, field_name: str) -> datetime:
+        return datetime.combine(self._parse_date_value(value, field_name), time.min, tzinfo=UTC)
+
+    def _parse_date_key(self, value: str) -> date:
+        return self._parse_date_value(value, "FX_DAILY date")
+
+    def _parse_date_value(self, value: str, field_name: str) -> date:
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:
+            raise AlphaVantageNormalizationError(
+                f"Alpha Vantage {field_name} is not an ISO date."
+            ) from exc
+
+    def _optional_string(self, value: Any) -> str | None:
+        if value in (None, "", "None", "-"):
+            return None
+        return str(value).strip()

--- a/comps-service/tests/test_alpha_vantage_provider.py
+++ b/comps-service/tests/test_alpha_vantage_provider.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import unittest
+
+from comps_service.alpha_vantage import (
+    AlphaVantageClient,
+    AlphaVantageConfigError,
+    AlphaVantageProviderError,
+)
+from comps_service.provider_normalizer import (
+    AlphaVantageCompsNormalizer,
+    AlphaVantageNormalizationError,
+)
+
+
+class AlphaVantageClientTest(unittest.TestCase):
+    def test_missing_api_key_raises_config_error(self) -> None:
+        client = AlphaVantageClient(api_key="", request_json=lambda _params: {})
+
+        with self.assertRaisesRegex(AlphaVantageConfigError, "ALPHA_VANTAGE_API_KEY"):
+            client.get_global_quote("AAPL")
+
+    def test_provider_error_payload_raises_provider_error(self) -> None:
+        client = AlphaVantageClient(
+            api_key="test",
+            request_json=lambda _params: {"Note": "rate limit reached"},
+        )
+
+        with self.assertRaisesRegex(AlphaVantageProviderError, "rate limit"):
+            client.get_overview("AAPL")
+
+
+class AlphaVantageCompsNormalizerTest(unittest.TestCase):
+    def test_usd_payload_normalizes_without_fx(self) -> None:
+        normalizer = AlphaVantageCompsNormalizer(_fixture_client(currency="USD"))
+
+        company = normalizer.normalize_company("AAPL", output_currency="USD")
+
+        self.assertEqual(company.ticker, "AAPL")
+        self.assertEqual(company.company_name, "Apple Inc.")
+        self.assertEqual(company.currency, "USD")
+        self.assertEqual(company.share_price, 10.0)
+        self.assertEqual(company.shares_outstanding, 100.0)
+        self.assertEqual(company.cash, 200.0)
+        self.assertEqual(company.total_debt, 500.0)
+        self.assertEqual(company.revenue_ltm, 250.0)
+        self.assertEqual(company.ebit_ltm, 100.0)
+        self.assertEqual(company.ebitda_ltm, 125.0)
+        self.assertEqual(company.net_income_ltm, 50.0)
+        self.assertEqual(company.as_of.isoformat(), "2026-06-26T00:00:00+00:00")
+        self.assertEqual(company.sources["cash"], "alpha_vantage.BALANCE_SHEET.quarterlyReports[0].cashAndCashEquivalentsAtCarryingValue")
+
+    def test_non_usd_payload_converts_money_with_fx(self) -> None:
+        normalizer = AlphaVantageCompsNormalizer(_fixture_client(currency="EUR", fx_rate="1.2"))
+
+        company = normalizer.normalize_company("SAP", output_currency="USD")
+
+        self.assertEqual(company.currency, "USD")
+        self.assertEqual(company.share_price, 12.0)
+        self.assertEqual(company.cash, 240.0)
+        self.assertEqual(company.total_debt, 600.0)
+        self.assertEqual(company.revenue_ltm, 300.0)
+        self.assertEqual(company.ebit_ltm, 120.0)
+        self.assertEqual(company.ebitda_ltm, 150.0)
+        self.assertEqual(company.net_income_ltm, 60.0)
+        self.assertIn("fx=EUR/USD@1.2 date=2026-06-26", company.sources["share_price"])
+        self.assertIn("fx=EUR/USD@1.2 date=2026-06-26", company.sources["revenue_ltm"])
+
+    def test_missing_required_financial_field_raises_normalization_error(self) -> None:
+        client = _fixture_client(currency="USD")
+        client.income_statement["quarterlyReports"][0].pop("totalRevenue")
+        normalizer = AlphaVantageCompsNormalizer(client)
+
+        with self.assertRaisesRegex(AlphaVantageNormalizationError, "totalRevenue"):
+            normalizer.normalize_company("AAPL", output_currency="USD")
+
+    def test_invalid_numeric_field_raises_normalization_error(self) -> None:
+        client = _fixture_client(currency="USD")
+        client.overview["SharesOutstanding"] = "not-a-number"
+        normalizer = AlphaVantageCompsNormalizer(client)
+
+        with self.assertRaisesRegex(AlphaVantageNormalizationError, "SharesOutstanding"):
+            normalizer.normalize_company("AAPL", output_currency="USD")
+
+    def test_missing_fx_data_raises_normalization_error(self) -> None:
+        client = _fixture_client(currency="EUR", fx_rate=None)
+        normalizer = AlphaVantageCompsNormalizer(client)
+
+        with self.assertRaisesRegex(AlphaVantageNormalizationError, "FX rate EUR/USD"):
+            normalizer.normalize_company("SAP", output_currency="USD")
+
+
+class _FixtureAlphaVantageClient:
+    def __init__(self, *, currency: str, fx_rate: str | None = "1.0") -> None:
+        self.quote = {
+            "Global Quote": {
+                "01. symbol": "AAPL",
+                "05. price": "10",
+                "07. latest trading day": "2026-06-26",
+            }
+        }
+        self.overview = {
+            "Symbol": "AAPL",
+            "Name": "Apple Inc.",
+            "Currency": currency,
+            "SharesOutstanding": "100",
+        }
+        self.income_statement = {
+            "symbol": "AAPL",
+            "quarterlyReports": [
+                _income_report(currency, "2026-03-31", revenue="100", ebit="40", ebitda="50", net_income="20"),
+                _income_report(currency, "2025-12-31", revenue="60", ebit="25", ebitda="30", net_income="15"),
+                _income_report(currency, "2025-09-30", revenue="50", ebit="20", ebitda="25", net_income="10"),
+                _income_report(currency, "2025-06-30", revenue="40", ebit="15", ebitda="20", net_income="5"),
+            ],
+        }
+        self.balance_sheet = {
+            "symbol": "AAPL",
+            "quarterlyReports": [
+                {
+                    "fiscalDateEnding": "2026-03-31",
+                    "reportedCurrency": currency,
+                    "cashAndCashEquivalentsAtCarryingValue": "200",
+                    "shortLongTermDebtTotal": "500",
+                }
+            ],
+        }
+        self.fx_daily = (
+            {"Time Series FX (Daily)": {"2026-06-26": {"4. close": fx_rate}}}
+            if fx_rate is not None
+            else {"Time Series FX (Daily)": {}}
+        )
+
+    def get_global_quote(self, symbol: str) -> dict[str, object]:
+        return self.quote
+
+    def get_overview(self, symbol: str) -> dict[str, object]:
+        return self.overview
+
+    def get_income_statement(self, symbol: str) -> dict[str, object]:
+        return self.income_statement
+
+    def get_balance_sheet(self, symbol: str) -> dict[str, object]:
+        return self.balance_sheet
+
+    def get_fx_daily(self, from_currency: str, to_currency: str) -> dict[str, object]:
+        return self.fx_daily
+
+
+def _fixture_client(currency: str, fx_rate: str | None = "1.0") -> _FixtureAlphaVantageClient:
+    return _FixtureAlphaVantageClient(currency=currency, fx_rate=fx_rate)
+
+
+def _income_report(
+    currency: str,
+    fiscal_date: str,
+    *,
+    revenue: str,
+    ebit: str,
+    ebitda: str,
+    net_income: str,
+) -> dict[str, str]:
+    return {
+        "fiscalDateEnding": fiscal_date,
+        "reportedCurrency": currency,
+        "totalRevenue": revenue,
+        "ebit": ebit,
+        "ebitda": ebitda,
+        "netIncome": net_income,
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary of all changes made from the end user perspective

This adds the Phase 3 Alpha Vantage provider normalization layer for `comps-service`. The service can now fetch the MVP Alpha Vantage payload shapes and convert them into the deterministic `CompanyCompsInput` model used by the calculator from Phase 2.

The normalization layer handles required financial fields, LTM income metrics from the latest four quarterly income reports, latest balance sheet cash/debt, quote price, company metadata, and explicit FX conversion when provider currency differs from the requested table currency.

This PR intentionally does not add API endpoint wiring, database writes, Redis cache behavior, run persistence, exports, Web BFF changes, or Agent Service changes.

Part of #5.

## Explanation of how these changes were made with a mermaid diagram showing the updated flow of things vs the original flow

The new provider layer is deliberately thin: `AlphaVantageClient` owns provider calls/errors, and `AlphaVantageCompsNormalizer` owns conversion from raw provider JSON into calculator-ready inputs. The calculator remains pure and unchanged.

```mermaid
flowchart LR
    subgraph Original[Before Phase 3]
        A[Explicit numeric inputs]
        B[CompsCalculator]
        A --> B
    end

    subgraph Updated[After Phase 3]
        C[Alpha Vantage JSON]
        D[AlphaVantageClient]
        E[AlphaVantageCompsNormalizer]
        F[CompanyCompsInput]
        G[CompsCalculator]
        C --> D
        D --> E
        E --> F
        F --> G
    end
```

Core behavior added:
- validates `ALPHA_VANTAGE_API_KEY`
- calls `GLOBAL_QUOTE`, `OVERVIEW`, `INCOME_STATEMENT`, `BALANCE_SHEET`, and `FX_DAILY`
- raises clear provider errors for Alpha Vantage error/rate-limit responses
- raises normalization errors for missing fields, invalid numbers, inconsistent currencies, or unavailable FX data
- records source labels, including FX pair, rate, and date when conversion is applied

## Tests ran or added to validate everything

Added `comps-service/tests/test_alpha_vantage_provider.py` using Python `unittest`.

Tests cover:
- USD payload normalizes without FX
- non-USD payload converts monetary fields with explicit FX rate
- missing API key raises config error
- provider error/rate-limit payload raises provider error
- missing required financial field raises normalization error
- invalid numeric field raises normalization error
- missing FX data raises normalization error

Commands run:

```bash
.venv/bin/python -m compileall shared comps-service
PYTHONPATH=shared:comps-service .venv/bin/python -m unittest discover -s comps-service/tests
```

Manual smoke:

```bash
PYTHONPATH=shared:comps-service .venv/bin/python <local Alpha Vantage smoke script>
```

Result: Alpha Vantage returned a quota/rate-limit response for the local key, and the client surfaced it as `AlphaVantageProviderError`. No secret key was printed or committed.
