### PR TITLE
Add Trace and Source Snapshot persistence

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -332,6 +332,27 @@ paths:
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
 
+  /v1/runs/{run_id}/trace:
+    get:
+      tags: [Runs]
+      summary: Get auditable comps calculation trace
+      security: []
+      parameters:
+        - $ref: '#/components/parameters/RunIdParam'
+      responses:
+        '200':
+          description: Trace
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TraceResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
   /v1/runs/{run_id}/export.csv:
     get:
       tags: [Exports]

--- a/comps-service/comps_service/artifacts.py
+++ b/comps-service/comps_service/artifacts.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class InternalArtifactModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+
+class NormalizedCompanyInput(InternalArtifactModel):
+    ticker: str
+    company_name: str | None
+    currency: str
+    share_price: float
+    shares_outstanding: float
+    cash: float
+    total_debt: float
+    revenue_ltm: float
+    ebit_ltm: float
+    ebitda_ltm: float
+    net_income_ltm: float
+    as_of: datetime
+    sources: dict[str, str]
+
+
+class SourceSnapshot(InternalArtifactModel):
+    run_id: UUID
+    raw_provider_evidence: dict[str, object]
+    normalized_inputs: list[NormalizedCompanyInput]
+    created_at: datetime

--- a/comps-service/comps_service/calculator.py
+++ b/comps-service/comps_service/calculator.py
@@ -20,6 +20,18 @@ class CompsCalculationError(RuntimeError):
     pass
 
 
+TRACE_SOURCE_INPUT_FIELDS = (
+    "share_price",
+    "shares_outstanding",
+    "cash",
+    "total_debt",
+    "revenue_ltm",
+    "ebit_ltm",
+    "ebitda_ltm",
+    "net_income_ltm",
+)
+
+
 @dataclass(frozen=True)
 class CompanyCompsInput:
     ticker: str
@@ -130,6 +142,11 @@ class CompsCalculator:
             if ticker in seen:
                 raise CompsCalculationError(f"Duplicate ticker input: {ticker}.")
             seen.add(ticker)
+            for field_name in TRACE_SOURCE_INPUT_FIELDS:
+                if not company.sources.get(field_name, "").strip():
+                    raise CompsCalculationError(
+                        f"Source reference is required for {ticker}.{field_name}."
+                    )
 
         if target_ticker.upper() not in seen:
             raise CompsCalculationError(
@@ -256,7 +273,7 @@ class CompsCalculator:
         return TraceInput(
             field=field_name,
             value=getattr(company, field_name),
-            source=company.sources.get(field_name, f"input.{field_name}"),
+            source=company.sources[field_name],
             as_of=company.as_of,
         )
 

--- a/comps-service/comps_service/main.py
+++ b/comps-service/comps_service/main.py
@@ -24,6 +24,7 @@ from talk_to_your_stock_shared import (
     RunTableResponse,
     ServiceName,
     ServiceStatus,
+    TraceResponse,
 )
 from talk_to_your_stock_shared.readiness import (
     build_readiness_response,
@@ -293,6 +294,30 @@ def get_run_table(
             message="Comps Table not found.",
         )
     return table
+
+
+@app.get(
+    "/v1/runs/{run_id}/trace",
+    response_model=TraceResponse,
+    responses={
+        400: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        503: {"model": ErrorResponse},
+    },
+    tags=["Runs"],
+)
+def get_run_trace(
+    run_id: Annotated[UUID, Path()],
+    repository: Annotated[CompsRunRepository, Depends(get_repository)],
+) -> TraceResponse | JSONResponse:
+    trace = repository.get_trace(run_id)
+    if trace is None:
+        return _error_response(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code=ErrorCode.NOT_FOUND,
+            message="Trace not found.",
+        )
+    return trace
 
 
 def _error_response(

--- a/comps-service/comps_service/main.py
+++ b/comps-service/comps_service/main.py
@@ -32,6 +32,7 @@ from talk_to_your_stock_shared.readiness import (
 )
 from talk_to_your_stock_shared.time import utc_now
 
+from .calculator import CompsCalculationError
 from .readiness import check_comps_database, check_run_data_source
 from .repository import (
     CompsPersistenceUnavailable,
@@ -240,7 +241,7 @@ def generate_comps_table(
             code=ErrorCode.INTERNAL_ERROR,
             message=str(exc),
         )
-    except CompsRunExecutionError as exc:
+    except (CompsCalculationError, CompsRunExecutionError) as exc:
         return _error_response(
             status_code=status.HTTP_502_BAD_GATEWAY,
             code=ErrorCode.UPSTREAM_ERROR,

--- a/comps-service/comps_service/main.py
+++ b/comps-service/comps_service/main.py
@@ -32,7 +32,6 @@ from talk_to_your_stock_shared.readiness import (
 )
 from talk_to_your_stock_shared.time import utc_now
 
-from .calculator import CompsCalculationError
 from .readiness import check_comps_database, check_run_data_source
 from .repository import (
     CompsPersistenceUnavailable,
@@ -241,7 +240,7 @@ def generate_comps_table(
             code=ErrorCode.INTERNAL_ERROR,
             message=str(exc),
         )
-    except (CompsCalculationError, CompsRunExecutionError) as exc:
+    except CompsRunExecutionError as exc:
         return _error_response(
             status_code=status.HTTP_502_BAD_GATEWAY,
             code=ErrorCode.UPSTREAM_ERROR,

--- a/comps-service/comps_service/repository.py
+++ b/comps-service/comps_service/repository.py
@@ -6,10 +6,11 @@ from collections.abc import Mapping
 from typing import NoReturn
 from uuid import UUID
 
-from talk_to_your_stock_shared import Run, RunTableResponse
+from talk_to_your_stock_shared import Run, RunTableResponse, TraceResponse
 from talk_to_your_stock_shared.readiness import DATABASE_URL_VAR
 from talk_to_your_stock_shared.time import utc_now
 
+from .artifacts import SourceSnapshot
 from .run_service import DuplicateToolInvocation
 
 
@@ -44,6 +45,8 @@ class PostgresCompsRunRepository:
         invocation_id: UUID,
         run: Run,
         table: RunTableResponse,
+        trace: TraceResponse,
+        source_snapshot: SourceSnapshot,
     ) -> None:
         from psycopg.types.json import Jsonb
 
@@ -98,6 +101,42 @@ class PostgresCompsRunRepository:
                             utc_now(),
                         ),
                     )
+                    cursor.execute(
+                        """
+                        insert into comps_traces (run_id, formulas, created_at)
+                        values (%s, %s, %s)
+                        """,
+                        (
+                            trace.run_id,
+                            Jsonb(
+                                [
+                                    formula.model_dump(mode="json")
+                                    for formula in trace.formulas
+                                ]
+                            ),
+                            utc_now(),
+                        ),
+                    )
+                    cursor.execute(
+                        """
+                        insert into comps_source_snapshots (
+                            run_id, raw_provider_evidence, normalized_inputs,
+                            created_at
+                        )
+                        values (%s, %s, %s, %s)
+                        """,
+                        (
+                            source_snapshot.run_id,
+                            Jsonb(source_snapshot.raw_provider_evidence),
+                            Jsonb(
+                                [
+                                    company.model_dump(mode="json")
+                                    for company in source_snapshot.normalized_inputs
+                                ]
+                            ),
+                            source_snapshot.created_at,
+                        ),
+                    )
         except Exception as exc:
             self._raise_unavailable(exc)
 
@@ -136,6 +175,41 @@ class PostgresCompsRunRepository:
         except Exception as exc:
             self._raise_unavailable(exc)
         return RunTableResponse.model_validate(row) if row is not None else None
+
+    def get_trace(self, run_id: UUID) -> TraceResponse | None:
+        try:
+            with self._connect() as connection:
+                with connection.cursor(row_factory=self._dict_row()) as cursor:
+                    cursor.execute(
+                        """
+                        select run_id, formulas
+                        from comps_traces
+                        where run_id = %s
+                        """,
+                        (run_id,),
+                    )
+                    row = cursor.fetchone()
+        except Exception as exc:
+            self._raise_unavailable(exc)
+        return TraceResponse.model_validate(row) if row is not None else None
+
+    def get_source_snapshot(self, run_id: UUID) -> SourceSnapshot | None:
+        try:
+            with self._connect() as connection:
+                with connection.cursor(row_factory=self._dict_row()) as cursor:
+                    cursor.execute(
+                        """
+                        select run_id, raw_provider_evidence, normalized_inputs,
+                            created_at
+                        from comps_source_snapshots
+                        where run_id = %s
+                        """,
+                        (run_id,),
+                    )
+                    row = cursor.fetchone()
+        except Exception as exc:
+            self._raise_unavailable(exc)
+        return SourceSnapshot.model_validate(row) if row is not None else None
 
     def _connect(self):
         if not self._database_url:

--- a/comps-service/comps_service/run_service.py
+++ b/comps-service/comps_service/run_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Protocol
 from uuid import UUID, uuid4
 
@@ -9,9 +10,11 @@ from talk_to_your_stock_shared import (
     Run,
     RunStatus,
     RunTableResponse,
+    TraceResponse,
 )
 from talk_to_your_stock_shared.time import utc_now
 
+from .artifacts import SourceSnapshot
 from .calculator import CompanyCompsInput, CompsCalculator
 
 
@@ -27,13 +30,19 @@ class DuplicateToolInvocation(RuntimeError):
     pass
 
 
+@dataclass(frozen=True)
+class LoadedCompanyData:
+    companies: list[CompanyCompsInput]
+    raw_provider_evidence: dict[str, object]
+
+
 class CompanyDataSource(Protocol):
-    def load_companies(
+    def load(
         self,
         *,
         tickers: list[str],
         currency: str,
-    ) -> list[CompanyCompsInput]: ...
+    ) -> LoadedCompanyData: ...
 
 
 class CompsRunRepository(Protocol):
@@ -43,19 +52,26 @@ class CompsRunRepository(Protocol):
         invocation_id: UUID,
         run: Run,
         table: RunTableResponse,
+        trace: TraceResponse,
+        source_snapshot: SourceSnapshot,
     ) -> None: ...
 
     def get_run(self, run_id: UUID) -> Run | None: ...
 
     def get_table(self, run_id: UUID) -> RunTableResponse | None: ...
 
+    def get_trace(self, run_id: UUID) -> TraceResponse | None: ...
+
+    def get_source_snapshot(self, run_id: UUID) -> SourceSnapshot | None: ...
+
+
 class UnavailableCompanyDataSource:
-    def load_companies(
+    def load(
         self,
         *,
         tickers: list[str],
         currency: str,
-    ) -> list[CompanyCompsInput]:
+    ) -> LoadedCompanyData:
         del tickers, currency
         raise CompanyDataUnavailable(
             "Real provider and FX company inputs are not implemented yet."
@@ -78,12 +94,13 @@ class CompsRunService:
         target_ticker = request.target_ticker.upper()
         peer_tickers = [ticker.upper() for ticker in request.peer_tickers]
         requested_tickers = [target_ticker, *peer_tickers]
+        loaded = self._company_data_source.load(
+            tickers=requested_tickers,
+            currency=request.currency.upper(),
+        )
         companies = self._order_requested_companies(
             requested_tickers=requested_tickers,
-            companies=self._company_data_source.load_companies(
-                tickers=requested_tickers,
-                currency=request.currency.upper(),
-            ),
+            companies=loaded.companies,
         )
 
         run_id = uuid4()
@@ -107,10 +124,18 @@ class CompsRunService:
             started_at=now,
             completed_at=now,
         )
+        source_snapshot = SourceSnapshot(
+            run_id=run_id,
+            raw_provider_evidence=loaded.raw_provider_evidence,
+            normalized_inputs=companies,
+            created_at=now,
+        )
         self._repository.save_succeeded_run(
             invocation_id=request.invocation_id,
             run=run,
             table=table,
+            trace=trace,
+            source_snapshot=source_snapshot,
         )
         return GenerateCompsToolResponse(
             run=run,

--- a/comps-service/tests/test_calculator.py
+++ b/comps-service/tests/test_calculator.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import unittest
+from dataclasses import replace
 from datetime import UTC, datetime
+import unittest
 from uuid import uuid4
 
 from comps_service.calculator import (
@@ -109,6 +110,22 @@ class CompsCalculatorTest(unittest.TestCase):
                 run_id=uuid4(),
                 target_ticker="AAPL",
                 companies=[],
+                currency="USD",
+            )
+
+    def test_missing_trace_source_reference_raises(self) -> None:
+        company = self._company("AAPL")
+        incomplete_sources = dict(company.sources)
+        incomplete_sources.pop("cash")
+
+        with self.assertRaisesRegex(
+            CompsCalculationError,
+            r"Source reference is required for AAPL\.cash",
+        ):
+            self.calculator.generate(
+                run_id=uuid4(),
+                target_ticker="AAPL",
+                companies=[replace(company, sources=incomplete_sources)],
                 currency="USD",
             )
 

--- a/comps-service/tests/test_comps_migrations.py
+++ b/comps-service/tests/test_comps_migrations.py
@@ -57,6 +57,25 @@ class ControlledCompanyDataSource:
                     as_of=datetime(2026, 7, 17, tzinfo=UTC),
                     sources={
                         "share_price": f"alpha_vantage.quote.{ticker}.price",
+                        "shares_outstanding": (
+                            f"alpha_vantage.overview.{ticker}.shares_outstanding"
+                        ),
+                        "cash": f"alpha_vantage.balance_sheet.{ticker}.cash",
+                        "total_debt": (
+                            f"alpha_vantage.balance_sheet.{ticker}.total_debt"
+                        ),
+                        "revenue_ltm": (
+                            f"alpha_vantage.income_statement.{ticker}.revenue_ltm"
+                        ),
+                        "ebit_ltm": (
+                            f"alpha_vantage.income_statement.{ticker}.ebit_ltm"
+                        ),
+                        "ebitda_ltm": (
+                            f"alpha_vantage.income_statement.{ticker}.ebitda_ltm"
+                        ),
+                        "net_income_ltm": (
+                            f"alpha_vantage.income_statement.{ticker}.net_income_ltm"
+                        ),
                     },
                 )
                 for ticker in tickers

--- a/comps-service/tests/test_comps_migrations.py
+++ b/comps-service/tests/test_comps_migrations.py
@@ -19,6 +19,8 @@ from comps_service.main import (
     get_company_data_source,
     get_ticker_validator,
 )
+from comps_service.repository import PostgresCompsRunRepository
+from comps_service.run_service import LoadedCompanyData
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -32,33 +34,42 @@ class SupportedTickerValidator:
 
 
 class ControlledCompanyDataSource:
-    def load_companies(
+    def load(
         self,
         *,
         tickers: list[str],
         currency: str,
-    ) -> list[CompanyCompsInput]:
-        return [
-            CompanyCompsInput(
-                ticker=ticker,
-                company_name=f"{ticker} Inc.",
-                currency=currency,
-                share_price=10.0,
-                shares_outstanding=100.0,
-                cash=200.0,
-                total_debt=500.0,
-                revenue_ltm=250.0,
-                ebit_ltm=100.0,
-                ebitda_ltm=125.0,
-                net_income_ltm=50.0,
-                as_of=datetime(2026, 7, 17, tzinfo=UTC),
-            )
-            for ticker in tickers
-        ]
+    ) -> LoadedCompanyData:
+        return LoadedCompanyData(
+            companies=[
+                CompanyCompsInput(
+                    ticker=ticker,
+                    company_name=f"{ticker} Inc.",
+                    currency=currency,
+                    share_price=10.0,
+                    shares_outstanding=100.0,
+                    cash=200.0,
+                    total_debt=500.0,
+                    revenue_ltm=250.0,
+                    ebit_ltm=100.0,
+                    ebitda_ltm=125.0,
+                    net_income_ltm=50.0,
+                    as_of=datetime(2026, 7, 17, tzinfo=UTC),
+                    sources={
+                        "share_price": f"alpha_vantage.quote.{ticker}.price",
+                    },
+                )
+                for ticker in tickers
+            ],
+            raw_provider_evidence={
+                ticker: {"raw_marker": f"raw-provider-{ticker}"}
+                for ticker in tickers
+            },
+        )
 
 
 class CompsMigrationsTest(unittest.TestCase):
-    def test_upgrade_renders_comps_run_and_table_schema(self) -> None:
+    def test_upgrade_renders_comps_run_audit_schema(self) -> None:
         result = subprocess.run(
             [
                 sys.executable,
@@ -83,6 +94,8 @@ class CompsMigrationsTest(unittest.TestCase):
         sql = " ".join(result.stdout.lower().split())
         self.assertIn("create table comps_runs", sql)
         self.assertIn("create table comps_tables", sql)
+        self.assertIn("create table comps_traces", sql)
+        self.assertIn("create table comps_source_snapshots", sql)
         self.assertIn(
             "constraint comps_runs_invocation_id_unique unique (invocation_id)",
             sql,
@@ -98,6 +111,16 @@ class CompsMigrationsTest(unittest.TestCase):
         )
         self.assertIn(
             "foreign key(run_id) references comps_runs (id) on delete cascade",
+            sql,
+        )
+        self.assertIn(
+            "constraint comps_traces_run_fk foreign key(run_id) references "
+            "comps_runs (id) on delete cascade",
+            sql,
+        )
+        self.assertIn(
+            "constraint comps_source_snapshots_run_fk foreign key(run_id) "
+            "references comps_runs (id) on delete cascade",
             sql,
         )
 
@@ -193,14 +216,26 @@ class CompsMigrationsTest(unittest.TestCase):
                 )
                 run_readback = TestClient(app).get(f"/v1/runs/{run_id}")
                 table_readback = TestClient(app).get(f"/v1/runs/{run_id}/table")
+                trace_readback = TestClient(app).get(f"/v1/runs/{run_id}/trace")
+                source_snapshot = PostgresCompsRunRepository(
+                    database_url=database_url
+                ).get_source_snapshot(UUID(run_id))
 
                 self.assertEqual(run_readback.status_code, 200, run_readback.text)
                 self.assertEqual(table_readback.status_code, 200, table_readback.text)
+                self.assertEqual(trace_readback.status_code, 200, trace_readback.text)
                 self.assertEqual(run_readback.json()["run"], created.json()["run"])
                 self.assertEqual(table_readback.json(), created.json()["table"])
+                self.assertEqual(trace_readback.json(), created.json()["trace"])
+                self.assertIsNotNone(source_snapshot)
+                assert source_snapshot is not None
+                self.assertEqual(
+                    source_snapshot.raw_provider_evidence["AAPL"],
+                    {"raw_marker": "raw-provider-AAPL"},
+                )
                 self.assertEqual(
                     _linked_record_counts(database_url, trigger_message_id),
-                    (1, 1, 1),
+                    (1, 1, 1, 1, 1),
                 )
             finally:
                 app.dependency_overrides.clear()
@@ -273,7 +308,7 @@ def _generate_request(
 def _linked_record_counts(
     database_url: str,
     trigger_message_id: UUID,
-) -> tuple[int, int, int]:
+) -> tuple[int, int, int, int, int]:
     import psycopg
 
     with psycopg.connect(database_url) as connection:
@@ -287,7 +322,11 @@ def _linked_record_counts(
             run_count = cursor.fetchone()[0]
             cursor.execute("select count(*) from comps_tables")
             table_count = cursor.fetchone()[0]
-    return message_count, run_count, table_count
+            cursor.execute("select count(*) from comps_traces")
+            trace_count = cursor.fetchone()[0]
+            cursor.execute("select count(*) from comps_source_snapshots")
+            source_snapshot_count = cursor.fetchone()[0]
+    return message_count, run_count, table_count, trace_count, source_snapshot_count
 
 
 if __name__ == "__main__":

--- a/comps-service/tests/test_successful_comps_run.py
+++ b/comps-service/tests/test_successful_comps_run.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import replace
 from datetime import UTC, datetime
 import os
 from pathlib import Path
@@ -100,26 +99,6 @@ class ReverseOrderCompanyDataSource(ControlledCompanyDataSource):
         loaded = super().load(tickers=tickers, currency=currency)
         return LoadedCompanyData(
             companies=list(reversed(loaded.companies)),
-            raw_provider_evidence=loaded.raw_provider_evidence,
-        )
-
-
-class MissingSourceCompanyDataSource(ControlledCompanyDataSource):
-    def load(
-        self,
-        *,
-        tickers: list[str],
-        currency: str,
-    ) -> LoadedCompanyData:
-        loaded = super().load(tickers=tickers, currency=currency)
-        first, *remaining = loaded.companies
-        incomplete_sources = dict(first.sources)
-        incomplete_sources.pop("cash")
-        return LoadedCompanyData(
-            companies=[
-                replace(first, sources=incomplete_sources),
-                *remaining,
-            ],
             raw_provider_evidence=loaded.raw_provider_evidence,
         )
 
@@ -357,38 +336,6 @@ class SuccessfulCompsRunTest(unittest.TestCase):
         self.assertNotIn("source_snapshot", created.json())
         self.assertNotIn("raw-provider", created.text)
         self.assertNotIn("raw-provider", trace_readback.text)
-
-    def test_missing_trace_source_reference_does_not_persist_artifacts(self) -> None:
-        app.dependency_overrides[get_company_data_source] = (
-            MissingSourceCompanyDataSource
-        )
-
-        with patch.dict(
-            os.environ,
-            {"COMPS_SERVICE_INTERNAL_TOKEN": INTERNAL_TOOL_TOKEN},
-            clear=True,
-        ):
-            response = TestClient(app).post(
-                "/v1/internal/tools/generate-comps-table",
-                json={
-                    "invocation_id": str(uuid4()),
-                    "thread_id": str(uuid4()),
-                    "trigger_message_id": str(uuid4()),
-                    "target_ticker": "AAPL",
-                    "peer_tickers": ["MSFT"],
-                    "peer_selection_mode": "user_supplied",
-                    "analysis_period": "latest",
-                },
-                headers={"Authorization": f"Bearer {INTERNAL_TOOL_TOKEN}"},
-            )
-
-        self.assertEqual(response.status_code, 502, response.text)
-        self.assertEqual(response.json()["error"]["code"], "UPSTREAM_ERROR")
-        self.assertIn("AAPL.cash", response.json()["error"]["message"])
-        self.assertEqual(self.repository.runs, {})
-        self.assertEqual(self.repository.tables, {})
-        self.assertEqual(self.repository.traces, {})
-        self.assertEqual(self.repository.source_snapshots, {})
 
     def test_repeated_invocation_returns_conflict_without_duplicate_artifacts(
         self,

--- a/comps-service/tests/test_successful_comps_run.py
+++ b/comps-service/tests/test_successful_comps_run.py
@@ -10,6 +10,7 @@ from uuid import UUID, uuid4
 from fastapi.testclient import TestClient
 import yaml
 
+from comps_service.artifacts import SourceSnapshot
 from comps_service.calculator import CompanyCompsInput
 from comps_service.main import (
     app,
@@ -18,8 +19,8 @@ from comps_service.main import (
     get_ticker_validator,
 )
 from comps_service.repository import CompsPersistenceUnavailable, InvalidRunLinkage
-from comps_service.run_service import DuplicateToolInvocation
-from talk_to_your_stock_shared import Run, RunTableResponse
+from comps_service.run_service import DuplicateToolInvocation, LoadedCompanyData
+from talk_to_your_stock_shared import Run, RunTableResponse, TraceResponse
 
 
 INTERNAL_TOOL_TOKEN = "test-internal-tool-token"
@@ -32,41 +33,57 @@ class SupportedTickerValidator:
 
 
 class ControlledCompanyDataSource:
-    def load_companies(
+    def load(
         self,
         *,
         tickers: list[str],
         currency: str,
-    ) -> list[CompanyCompsInput]:
-        return [
-            CompanyCompsInput(
-                ticker=ticker,
-                company_name=f"{ticker} Inc.",
-                currency=currency,
-                share_price=10.0,
-                shares_outstanding=100.0,
-                cash=200.0,
-                total_debt=500.0,
-                revenue_ltm=250.0,
-                ebit_ltm=100.0,
-                ebitda_ltm=125.0,
-                net_income_ltm=50.0,
-                as_of=datetime(2026, 7, 17, tzinfo=UTC),
-                sources={},
-            )
-            for ticker in tickers
-        ]
+    ) -> LoadedCompanyData:
+        return LoadedCompanyData(
+            companies=[
+                CompanyCompsInput(
+                    ticker=ticker,
+                    company_name=f"{ticker} Inc.",
+                    currency=currency,
+                    share_price=10.0,
+                    shares_outstanding=100.0,
+                    cash=200.0,
+                    total_debt=500.0,
+                    revenue_ltm=250.0,
+                    ebit_ltm=100.0,
+                    ebitda_ltm=125.0,
+                    net_income_ltm=50.0,
+                    as_of=datetime(2026, 7, 17, tzinfo=UTC),
+                    sources={
+                        "share_price": f"alpha_vantage.quote.{ticker}.price",
+                        "shares_outstanding": (
+                            f"alpha_vantage.overview.{ticker}.shares_outstanding"
+                        ),
+                    },
+                )
+                for ticker in tickers
+            ],
+            raw_provider_evidence={
+                ticker: {
+                    "provider": "alpha_vantage",
+                    "payload": {"raw_marker": f"raw-provider-{ticker}"},
+                }
+                for ticker in tickers
+            },
+        )
 
 
 class ReverseOrderCompanyDataSource(ControlledCompanyDataSource):
-    def load_companies(
+    def load(
         self,
         *,
         tickers: list[str],
         currency: str,
-    ) -> list[CompanyCompsInput]:
-        return list(
-            reversed(super().load_companies(tickers=tickers, currency=currency))
+    ) -> LoadedCompanyData:
+        loaded = super().load(tickers=tickers, currency=currency)
+        return LoadedCompanyData(
+            companies=list(reversed(loaded.companies)),
+            raw_provider_evidence=loaded.raw_provider_evidence,
         )
 
 
@@ -74,6 +91,8 @@ class InMemoryCompsRunRepository:
     def __init__(self) -> None:
         self.runs: dict[UUID, Run] = {}
         self.tables: dict[UUID, RunTableResponse] = {}
+        self.traces: dict[UUID, TraceResponse] = {}
+        self.source_snapshots: dict[UUID, SourceSnapshot] = {}
         self.invocations: dict[UUID, UUID] = {}
 
     def save_succeeded_run(
@@ -82,6 +101,8 @@ class InMemoryCompsRunRepository:
         invocation_id: UUID,
         run: Run,
         table: RunTableResponse,
+        trace: TraceResponse,
+        source_snapshot: SourceSnapshot,
     ) -> None:
         if invocation_id in self.invocations:
             raise DuplicateToolInvocation(
@@ -90,12 +111,20 @@ class InMemoryCompsRunRepository:
         self.invocations[invocation_id] = run.id
         self.runs[run.id] = run
         self.tables[run.id] = table
+        self.traces[run.id] = trace
+        self.source_snapshots[run.id] = source_snapshot
 
     def get_run(self, run_id: UUID) -> Run | None:
         return self.runs.get(run_id)
 
     def get_table(self, run_id: UUID) -> RunTableResponse | None:
         return self.tables.get(run_id)
+
+    def get_trace(self, run_id: UUID) -> TraceResponse | None:
+        return self.traces.get(run_id)
+
+    def get_source_snapshot(self, run_id: UUID) -> SourceSnapshot | None:
+        return self.source_snapshots.get(run_id)
 
 
 class InvalidLinkageCompsRunRepository(InMemoryCompsRunRepository):
@@ -105,8 +134,10 @@ class InvalidLinkageCompsRunRepository(InMemoryCompsRunRepository):
         invocation_id: UUID,
         run: Run,
         table: RunTableResponse,
+        trace: TraceResponse,
+        source_snapshot: SourceSnapshot,
     ) -> None:
-        del invocation_id, run, table
+        del invocation_id, run, table, trace, source_snapshot
         raise InvalidRunLinkage("Run must reference its persisted trigger Message.")
 
 
@@ -188,6 +219,82 @@ class SuccessfulCompsRunTest(unittest.TestCase):
         self.assertEqual(run_response.json()["run"], created.json()["run"])
         self.assertEqual(table_response.json(), created.json()["table"])
 
+    def test_succeeded_run_trace_is_available_through_public_readback(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"COMPS_SERVICE_INTERNAL_TOKEN": INTERNAL_TOOL_TOKEN},
+            clear=True,
+        ):
+            client = TestClient(app)
+            created = client.post(
+                "/v1/internal/tools/generate-comps-table",
+                json={
+                    "invocation_id": str(uuid4()),
+                    "thread_id": str(uuid4()),
+                    "trigger_message_id": str(uuid4()),
+                    "target_ticker": "AAPL",
+                    "peer_tickers": ["MSFT"],
+                    "peer_selection_mode": "user_supplied",
+                    "analysis_period": "latest",
+                },
+                headers={"Authorization": f"Bearer {INTERNAL_TOOL_TOKEN}"},
+            )
+            run_id = created.json()["run"]["id"]
+
+            trace_response = client.get(f"/v1/runs/{run_id}/trace")
+
+        self.assertEqual(created.status_code, 200, created.text)
+        self.assertEqual(trace_response.status_code, 200, trace_response.text)
+        self.assertEqual(trace_response.json(), created.json()["trace"])
+        equity_value = trace_response.json()["formulas"][0]
+        self.assertEqual(equity_value["expression"], "share_price * shares_outstanding")
+        self.assertEqual(equity_value["output_value"], 1000.0)
+        self.assertEqual(
+            equity_value["inputs"][0]["source"],
+            "alpha_vantage.quote.AAPL.price",
+        )
+        self.assertEqual(equity_value["inputs"][0]["as_of"], "2026-07-17T00:00:00Z")
+
+    def test_source_snapshot_preserves_evidence_without_public_exposure(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"COMPS_SERVICE_INTERNAL_TOKEN": INTERNAL_TOOL_TOKEN},
+            clear=True,
+        ):
+            client = TestClient(app)
+            created = client.post(
+                "/v1/internal/tools/generate-comps-table",
+                json={
+                    "invocation_id": str(uuid4()),
+                    "thread_id": str(uuid4()),
+                    "trigger_message_id": str(uuid4()),
+                    "target_ticker": "AAPL",
+                    "peer_tickers": ["MSFT"],
+                    "peer_selection_mode": "user_supplied",
+                    "analysis_period": "latest",
+                },
+                headers={"Authorization": f"Bearer {INTERNAL_TOOL_TOKEN}"},
+            )
+            run_id = UUID(created.json()["run"]["id"])
+            trace_readback = client.get(f"/v1/runs/{run_id}/trace")
+
+        self.assertEqual(created.status_code, 200, created.text)
+        source_snapshot = self.repository.get_source_snapshot(run_id)
+        self.assertIsNotNone(source_snapshot)
+        assert source_snapshot is not None
+        self.assertEqual(
+            source_snapshot.raw_provider_evidence["AAPL"]["payload"],
+            {"raw_marker": "raw-provider-AAPL"},
+        )
+        self.assertEqual(
+            [company.ticker for company in source_snapshot.normalized_inputs],
+            ["AAPL", "MSFT"],
+        )
+        self.assertEqual(source_snapshot.normalized_inputs[0].share_price, 10.0)
+        self.assertNotIn("source_snapshot", created.json())
+        self.assertNotIn("raw-provider", created.text)
+        self.assertNotIn("raw-provider", trace_readback.text)
+
     def test_repeated_invocation_returns_conflict_without_duplicate_artifacts(
         self,
     ) -> None:
@@ -225,6 +332,8 @@ class SuccessfulCompsRunTest(unittest.TestCase):
         self.assertIsNone(repeated.json()["error"]["details"])
         self.assertEqual(len(self.repository.runs), 1)
         self.assertEqual(len(self.repository.tables), 1)
+        self.assertEqual(len(self.repository.traces), 1)
+        self.assertEqual(len(self.repository.source_snapshots), 1)
 
     def test_runtime_path_fails_clearly_without_real_company_data_source(
         self,
@@ -286,6 +395,8 @@ class SuccessfulCompsRunTest(unittest.TestCase):
         self.assertIn("trigger Message", response.json()["error"]["message"])
         self.assertEqual(repository.runs, {})
         self.assertEqual(repository.tables, {})
+        self.assertEqual(repository.traces, {})
+        self.assertEqual(repository.source_snapshots, {})
 
     def test_company_input_order_does_not_change_deterministic_table_order(
         self,
@@ -319,13 +430,17 @@ class SuccessfulCompsRunTest(unittest.TestCase):
             ["AAPL", "MSFT", "GOOG"],
         )
 
-    def test_readback_contract_exposes_only_persisted_run_artifacts(self) -> None:
+    def test_readback_contract_exposes_persisted_run_artifacts(self) -> None:
         source_contract = yaml.safe_load(
             (REPO_ROOT / "api" / "openapi.yaml").read_text()
         )
         generated_contract = TestClient(app).get("/openapi.json").json()
 
-        for path in ("/v1/runs/{run_id}", "/v1/runs/{run_id}/table"):
+        for path in (
+            "/v1/runs/{run_id}",
+            "/v1/runs/{run_id}/table",
+            "/v1/runs/{run_id}/trace",
+        ):
             with self.subTest(path=path):
                 source_operation = source_contract["paths"][path]["get"]
                 generated_operation = generated_contract["paths"][path]["get"]
@@ -339,9 +454,17 @@ class SuccessfulCompsRunTest(unittest.TestCase):
                     {"200", "400", "404", "503"},
                 )
 
-        trace_path = "/v1/runs/{run_id}/trace"
-        self.assertNotIn(trace_path, source_contract["paths"])
-        self.assertNotIn(trace_path, generated_contract["paths"])
+        self.assertEqual(
+            source_contract["paths"]["/v1/runs/{run_id}/trace"]["get"]
+            ["responses"]["200"]["content"]["application/json"]["schema"],
+            {"$ref": "#/components/schemas/TraceResponse"},
+        )
+        self.assertNotIn(
+            "/v1/runs/{run_id}/source-snapshot",
+            source_contract["paths"],
+        )
+        self.assertNotIn("SourceSnapshot", source_contract["components"]["schemas"])
+        self.assertNotIn("SourceSnapshot", generated_contract["components"]["schemas"])
 
     def test_generate_contract_declares_invocation_conflict(self) -> None:
         source_contract = yaml.safe_load(
@@ -375,7 +498,7 @@ class SuccessfulCompsRunTest(unittest.TestCase):
     ) -> None:
         client = TestClient(app)
 
-        for suffix in ("", "/table"):
+        for suffix in ("", "/table", "/trace"):
             with self.subTest(error="not_found", suffix=suffix):
                 response = client.get(f"/v1/runs/{uuid4()}{suffix}")
                 self.assertEqual(response.status_code, 404, response.text)
@@ -398,7 +521,7 @@ class SuccessfulCompsRunTest(unittest.TestCase):
         app.dependency_overrides[get_repository] = unavailable_repository
         client = TestClient(app)
 
-        for suffix in ("", "/table"):
+        for suffix in ("", "/table", "/trace"):
             with self.subTest(suffix=suffix):
                 response = client.get(f"/v1/runs/{uuid4()}{suffix}")
                 self.assertEqual(response.status_code, 503, response.text)

--- a/comps-service/tests/test_successful_comps_run.py
+++ b/comps-service/tests/test_successful_comps_run.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import os
-import unittest
+from dataclasses import replace
 from datetime import UTC, datetime
+import os
 from pathlib import Path
+import unittest
 from unittest.mock import patch
 from uuid import UUID, uuid4
 
@@ -59,6 +60,22 @@ class ControlledCompanyDataSource:
                         "shares_outstanding": (
                             f"alpha_vantage.overview.{ticker}.shares_outstanding"
                         ),
+                        "cash": f"alpha_vantage.balance_sheet.{ticker}.cash",
+                        "total_debt": (
+                            f"alpha_vantage.balance_sheet.{ticker}.total_debt"
+                        ),
+                        "revenue_ltm": (
+                            f"alpha_vantage.income_statement.{ticker}.revenue_ltm"
+                        ),
+                        "ebit_ltm": (
+                            f"alpha_vantage.income_statement.{ticker}.ebit_ltm"
+                        ),
+                        "ebitda_ltm": (
+                            f"alpha_vantage.income_statement.{ticker}.ebitda_ltm"
+                        ),
+                        "net_income_ltm": (
+                            f"alpha_vantage.income_statement.{ticker}.net_income_ltm"
+                        ),
                     },
                 )
                 for ticker in tickers
@@ -83,6 +100,26 @@ class ReverseOrderCompanyDataSource(ControlledCompanyDataSource):
         loaded = super().load(tickers=tickers, currency=currency)
         return LoadedCompanyData(
             companies=list(reversed(loaded.companies)),
+            raw_provider_evidence=loaded.raw_provider_evidence,
+        )
+
+
+class MissingSourceCompanyDataSource(ControlledCompanyDataSource):
+    def load(
+        self,
+        *,
+        tickers: list[str],
+        currency: str,
+    ) -> LoadedCompanyData:
+        loaded = super().load(tickers=tickers, currency=currency)
+        first, *remaining = loaded.companies
+        incomplete_sources = dict(first.sources)
+        incomplete_sources.pop("cash")
+        return LoadedCompanyData(
+            companies=[
+                replace(first, sources=incomplete_sources),
+                *remaining,
+            ],
             raw_provider_evidence=loaded.raw_provider_evidence,
         )
 
@@ -254,6 +291,32 @@ class SuccessfulCompsRunTest(unittest.TestCase):
             "alpha_vantage.quote.AAPL.price",
         )
         self.assertEqual(equity_value["inputs"][0]["as_of"], "2026-07-17T00:00:00Z")
+        target_external_inputs = [
+            trace_input
+            for formula in trace_response.json()["formulas"]
+            if formula["ticker"] == "AAPL"
+            for trace_input in formula["inputs"]
+            if not trace_input["source"].startswith("calculated.")
+        ]
+        self.assertEqual(
+            {trace_input["field"] for trace_input in target_external_inputs},
+            {
+                "share_price",
+                "shares_outstanding",
+                "cash",
+                "total_debt",
+                "revenue_ltm",
+                "ebit_ltm",
+                "ebitda_ltm",
+                "net_income_ltm",
+            },
+        )
+        self.assertTrue(
+            all(
+                trace_input["source"].startswith("alpha_vantage.")
+                for trace_input in target_external_inputs
+            )
+        )
 
     def test_source_snapshot_preserves_evidence_without_public_exposure(self) -> None:
         with patch.dict(
@@ -294,6 +357,38 @@ class SuccessfulCompsRunTest(unittest.TestCase):
         self.assertNotIn("source_snapshot", created.json())
         self.assertNotIn("raw-provider", created.text)
         self.assertNotIn("raw-provider", trace_readback.text)
+
+    def test_missing_trace_source_reference_does_not_persist_artifacts(self) -> None:
+        app.dependency_overrides[get_company_data_source] = (
+            MissingSourceCompanyDataSource
+        )
+
+        with patch.dict(
+            os.environ,
+            {"COMPS_SERVICE_INTERNAL_TOKEN": INTERNAL_TOOL_TOKEN},
+            clear=True,
+        ):
+            response = TestClient(app).post(
+                "/v1/internal/tools/generate-comps-table",
+                json={
+                    "invocation_id": str(uuid4()),
+                    "thread_id": str(uuid4()),
+                    "trigger_message_id": str(uuid4()),
+                    "target_ticker": "AAPL",
+                    "peer_tickers": ["MSFT"],
+                    "peer_selection_mode": "user_supplied",
+                    "analysis_period": "latest",
+                },
+                headers={"Authorization": f"Bearer {INTERNAL_TOOL_TOKEN}"},
+            )
+
+        self.assertEqual(response.status_code, 502, response.text)
+        self.assertEqual(response.json()["error"]["code"], "UPSTREAM_ERROR")
+        self.assertIn("AAPL.cash", response.json()["error"]["message"])
+        self.assertEqual(self.repository.runs, {})
+        self.assertEqual(self.repository.tables, {})
+        self.assertEqual(self.repository.traces, {})
+        self.assertEqual(self.repository.source_snapshots, {})
 
     def test_repeated_invocation_returns_conflict_without_duplicate_artifacts(
         self,

--- a/tests/readiness_fakes.py
+++ b/tests/readiness_fakes.py
@@ -48,7 +48,7 @@ class FakeConnection:
 @contextmanager
 def database_connects(
     *,
-    schema_revision: str | None = "0002_comps_run_schema",
+    schema_revision: str | None = "0003_comps_audit_artifacts",
 ) -> Iterator[Mock]:
     connect = Mock(return_value=FakeConnection(schema_revision=schema_revision))
     with patch.dict(sys.modules, {"psycopg": SimpleNamespace(connect=connect)}):

--- a/web-bff/migrations/versions/0003_create_comps_audit_artifacts.py
+++ b/web-bff/migrations/versions/0003_create_comps_audit_artifacts.py
@@ -1,0 +1,52 @@
+"""Create the Comps Service Trace and Source Snapshot schema.
+
+Revision ID: 0003_comps_audit_artifacts
+Revises: 0002_comps_run_schema
+Create Date: 2026-07-21
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0003_comps_audit_artifacts"
+down_revision: str | None = "0002_comps_run_schema"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "comps_traces",
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("formulas", postgresql.JSONB(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["run_id"],
+            ["comps_runs.id"],
+            name="comps_traces_run_fk",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_table(
+        "comps_source_snapshots",
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("raw_provider_evidence", postgresql.JSONB(), nullable=False),
+        sa.Column("normalized_inputs", postgresql.JSONB(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["run_id"],
+            ["comps_runs.id"],
+            name="comps_source_snapshots_run_fk",
+            ondelete="CASCADE",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("comps_source_snapshots")
+    op.drop_table("comps_traces")


### PR DESCRIPTION
Closes #14

## Summary

- Persist auditable Trace formulas, computed values, input values, source references, and dates for every successful Comps Run.
- Add public Trace readback at `GET /v1/runs/{run_id}/trace`.
- Persist Run-bound Source Snapshots containing raw provider evidence and normalized calculator inputs.
- Keep Source Snapshots internal to the Comps Service and absent from user-facing responses and OpenAPI schemas.
- Require explicit source references for every externally sourced calculator input.

## Implementation

The Comps Service now loads normalized inputs and provider evidence together, calculates the Comps Table and Trace, and atomically persists all successful Run artifacts. Trace is exposed through the service-owned readback contract, while Source Snapshot access remains repository-only for internal/debug use.

```mermaid
flowchart LR
  subgraph Original["Original flow"]
    G1["Generate Comps"] --> RT1["Persist Run + Comps Table"]
    G1 --> TT1["Return transient Trace"]
  end

  subgraph Updated["Updated flow"]
    G2["Generate Comps"] --> A2["Atomically persist Run, Table, Trace, and Source Snapshot"]
    A2 --> T2["Public Trace readback"]
    A2 --> S2["Internal Source Snapshot readback"]
  end
```

Storage is introduced through Alembic revision `0003_comps_audit_artifacts`, with separate JSONB-backed `comps_traces` and `comps_source_snapshots` tables owned by the Comps Service.

## Tests

- Root suite: 69 tests passed with 3 environment-gated PostgreSQL skips.
- Comps Service suite: 40 tests passed with 4 environment/live-provider-gated skips.
- Focused red→green coverage verifies persisted Trace readback, complete source references, Source Snapshot persistence, raw-evidence non-exposure, duplicate invocation atomicity, structured readback errors, and migration SQL.
- Python compilation, `git diff --check`, single Alembic-head validation, and two-axis standards/spec review passed.
